### PR TITLE
Remove text-center to match other paragraphs

### DIFF
--- a/index.html
+++ b/index.html
@@ -141,7 +141,7 @@
     <span>What is a Makeathon?</span>
 
     <!-- CONTENT -->
-    <p style=text-align:center;>
+    <p>
         A Makeathon is similar to a Hackathon. Both are events where participants build awesome projects from scratch in just a few short hours. Both can be 24 or 36 hour events--we will be holding a 24 hour event. The difference between a MAKEathon and a HACKathon is that we are encouraging projects to be Hardware oriented, and therefore physically <i>making</i> something!
         <br>
 <br>


### PR DESCRIPTION
Currently the paragraph for "What is a Makeathon?" is center-aligned while the others are left-aligned.